### PR TITLE
Initial scaffold for real-time bluffing game

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/j_cain_game"
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET="changeme-to-32-chars"
+EMAIL_SERVER_USER=""
+EMAIL_SERVER_PASS=""
+EMAIL_SERVER_HOST=""
+EMAIL_SERVER_PORT="587"

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['next', 'prettier'],
+};

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_DB: j_cain_game
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - '5432:5432'
+  web:
+    build: .
+    command: pnpm start
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/j_cain_game
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: changeme-to-32-chars
+    ports:
+      - '3000:3000'
+    depends_on:
+      - db

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: { appDir: true },
+};
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "would-i-lie-to-you",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "pnpm prisma migrate deploy && next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "vitest",
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.10.2",
+    "@types/socket.io-client": "^1.4.6",
+    "framer-motion": "^10.16.0",
+    "next": "14.0.4",
+    "next-auth": "^5.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "socket.io-client": "^4.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.0",
+    "@types/react": "18.2.24",
+    "autoprefixer": "10.4.17",
+    "eslint": "8.55.0",
+    "eslint-config-next": "14.0.4",
+    "postcss": "8.4.31",
+    "prettier": "3.1.0",
+    "prisma": "^5.10.2",
+    "tailwindcss": "3.3.5",
+    "ts-node": "10.9.1",
+    "typescript": "5.2.2",
+    "vitest": "1.0.4"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,74 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id       String   @id @default(cuid())
+  email    String   @unique
+  password String?
+  name     String?
+  games    GameUser[]
+  statements Statement[]
+  votes    Vote[]
+  scores   Score[]
+}
+
+model Game {
+  id        String      @id @default(cuid())
+  createdAt DateTime    @default(now())
+  hostId    String
+  host      User        @relation(fields: [hostId], references: [id])
+  rounds    Round[]
+  players   GameUser[]
+}
+
+model GameUser {
+  gameId String
+  userId String
+  game   Game @relation(fields: [gameId], references: [id])
+  user   User @relation(fields: [userId], references: [id])
+  @@id([gameId, userId])
+}
+
+model Round {
+  id            String     @id @default(cuid())
+  gameId        String
+  storytellerId String
+  statement     Statement?
+  votes         Vote[]
+  game          Game       @relation(fields: [gameId], references: [id])
+  storyteller   User       @relation(fields: [storytellerId], references: [id])
+}
+
+model Statement {
+  id      String   @id @default(cuid())
+  roundId String   @unique
+  content String   @db.VarChar(280)
+  truth   Boolean
+  round   Round    @relation(fields: [roundId], references: [id])
+}
+
+model Vote {
+  id      String @id @default(cuid())
+  roundId String
+  userId  String
+  truth   Boolean
+  round   Round  @relation(fields: [roundId], references: [id])
+  user    User   @relation(fields: [userId], references: [id])
+  @@unique([roundId, userId])
+}
+
+model Score {
+  id     String @id @default(cuid())
+  userId String
+  gameId String
+  points Int    @default(0)
+  user   User   @relation(fields: [userId], references: [id])
+  game   Game   @relation(fields: [gameId], references: [id])
+  @@unique([userId, gameId])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,36 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  const users = await Promise.all(
+    Array.from({ length: 10 }).map((_, i) =>
+      prisma.user.create({
+        data: {
+          email: `user${i + 1}@demo.com`,
+          password: 'password',
+          name: `User ${i + 1}`,
+        },
+      })
+    )
+  );
+  const game = await prisma.game.create({
+    data: {
+      hostId: users[0].id,
+      players: { create: users.map((u) => ({ userId: u.id })) },
+    },
+  });
+  await prisma.round.create({
+    data: {
+      gameId: game.id,
+      storytellerId: users[0].id,
+      statement: {
+        create: { content: 'I once ate a whole lemon', truth: false },
+      },
+    },
+  });
+  console.log('Seeded DB with demo game:', game.id);
+}
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,2 @@
+import { handlers } from '../../../../lib/auth';
+export const { GET, POST } = handlers;

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,9 @@
+import { prisma } from '../../../../lib/prisma';
+import { NextResponse } from 'next/server';
+
+/** Create a new user via POST */
+export async function POST(req: Request) {
+  const { email, password } = await req.json();
+  await prisma.user.create({ data: { email, password } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/game/[gameId]/route.ts
+++ b/src/app/api/game/[gameId]/route.ts
@@ -1,0 +1,22 @@
+import { prisma } from '../../../../lib/prisma';
+import { NextResponse } from 'next/server';
+import { auth } from '../../../../lib/auth';
+
+/** Fetch game state */
+export async function GET(_: Request, { params }: { params: { gameId: string } }) {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const game = await prisma.game.findUnique({
+    where: { id: params.gameId },
+    include: { rounds: { include: { statement: true, votes: true } }, players: true },
+  });
+  return NextResponse.json(game);
+}
+
+/** Update game state with new round or vote */
+export async function POST(req: Request, { params }: { params: { gameId: string } }) {
+  const data = await req.json();
+  // Simplified demo update
+  await prisma.game.update({ where: { id: params.gameId }, data });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/socket/route.ts
+++ b/src/app/api/socket/route.ts
@@ -1,0 +1,9 @@
+import { initSocket } from '../../../lib/socket';
+import { NextResponse } from 'next/server';
+
+export function GET(req: Request, res: any) {
+  initSocket(res);
+  res.end();
+}
+
+export const dynamic = 'force-dynamic';

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { signIn } from 'next-auth/react';
+import { useState } from 'react';
+import Button from '../../../components/Button';
+
+export default function SignIn() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <input className="border p-2" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+      <input className="border p-2" type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <Button onClick={() => signIn('credentials', { email, password })}>Sign In</Button>
+      <Button onClick={() => signIn('email', { email })}>Magic Link</Button>
+    </div>
+  );
+}

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useState } from 'react';
+import Button from '../../../components/Button';
+
+export default function SignUp() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const create = async () => {
+    await fetch('/api/auth/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <input className="border p-2" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+      <input className="border p-2" type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <Button onClick={create}>Sign Up</Button>
+    </div>
+  );
+}

--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import useSWR from 'swr';
+import { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+import Button from '../../../components/Button';
+import Timer from '../../../components/Timer';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function Game({ params }: { params: { gameId: string } }) {
+  const { data, mutate } = useSWR(`/api/game/${params.gameId}`, fetcher);
+  const [vote, setVote] = useState<boolean | null>(null);
+  useEffect(() => {
+    const socket = io({ path: '/api/socket' });
+    socket.emit('join', params.gameId);
+    socket.on('state', mutate);
+  }, []);
+  if (!data) return null;
+  const round = data.rounds[data.rounds.length - 1];
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl">Round</h1>
+      {round?.statement && <p className="text-xl">{round.statement.content}</p>}
+      {!vote ? (
+        <div className="space-x-4">
+          <Button onClick={() => setVote(true)}>Truth</Button>
+          <Button onClick={() => setVote(false)}>Lie</Button>
+        </div>
+      ) : (
+        <p>Waiting for others...</p>
+      )}
+      <Timer seconds={30} />
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import { Providers } from './providers';
+import { ReactNode } from 'react';
+
+export const metadata = { title: 'Would I Lie To You?' };
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/src/app/lobby/[gameId]/page.tsx
+++ b/src/app/lobby/[gameId]/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+import useSWR from 'swr';
+import { useRouter } from 'next/navigation';
+import Button from '../../../components/Button';
+import { useEffect } from 'react';
+import { io } from 'socket.io-client';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function Lobby({ params }: { params: { gameId: string } }) {
+  const { data } = useSWR(`/api/game/${params.gameId}`, fetcher, { refreshInterval: 1000 });
+  const router = useRouter();
+  useEffect(() => {
+    const socket = io({ path: '/api/socket' });
+    socket.emit('join', params.gameId);
+    socket.on('state', (state) => {
+      if (state.started) router.push(`/game/${params.gameId}`);
+    });
+  }, []);
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl">Lobby</h1>
+      <p>{data?.players?.length || 0} players joined</p>
+      <Button onClick={() => fetch(`/api/game/${params.gameId}`, { method: 'POST', body: JSON.stringify({ started: true }) })}>Start</Button>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import Button from '../components/Button';
+
+export default function Home() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <h1 className="text-4xl font-bold">Would I Lie To You?</h1>
+      <p>Bluff your friends in real-time.</p>
+      <Link href="/auth/signin">
+        <Button>Get Started</Button>
+      </Link>
+    </main>
+  );
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,8 @@
+'use client';
+import { SessionProvider } from 'next-auth/react';
+import { ReactNode } from 'react';
+
+/** App-level providers */
+export function Providers({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/app/results/[gameId]/page.tsx
+++ b/src/app/results/[gameId]/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function Results({ params }: { params: { gameId: string } }) {
+  const { data } = useSWR(`/api/game/${params.gameId}`, fetcher);
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl">Results</h1>
+      <ul>
+        {data?.scores?.map((s: any) => (
+          <li key={s.id}>{s.userId}: {s.points}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,15 @@
+import { motion } from 'framer-motion';
+import { ButtonHTMLAttributes } from 'react';
+
+/** Animated button used throughout the app */
+export default function Button({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <motion.button
+      whileTap={{ scale: 0.95 }}
+      className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+      {...props}
+    >
+      {children}
+    </motion.button>
+  );
+}

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+/** Countdown timer */
+export default function Timer({ seconds, onEnd }: { seconds: number; onEnd?: () => void }) {
+  const [time, setTime] = useState(seconds);
+  useEffect(() => {
+    if (!time) return onEnd?.();
+    const id = setTimeout(() => setTime(time - 1), 1000);
+    return () => clearTimeout(id);
+  }, [time]);
+  return <span>{time}</span>;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,38 @@
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import Email from 'next-auth/providers/email';
+import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import { prisma } from './prisma';
+import type { NextAuthOptions } from 'next-auth';
+
+/** Configure NextAuth with email/password and magic link */
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    Credentials({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email) return null;
+        const user = await prisma.user.findUnique({ where: { email: credentials.email } });
+        if (user && credentials.password === user.password) return user;
+        return null;
+      },
+    }),
+    Email({ server: process.env.EMAIL_SERVER_HOST ? {
+      host: process.env.EMAIL_SERVER_HOST,
+      port: Number(process.env.EMAIL_SERVER_PORT || 587),
+      auth: {
+        user: process.env.EMAIL_SERVER_USER,
+        pass: process.env.EMAIL_SERVER_PASS,
+      },
+    } : undefined }),
+  ],
+  session: { strategy: 'jwt' },
+  pages: { signIn: '/auth/signin' },
+};
+
+export const { handlers, auth } = NextAuth(authOptions);

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+/** Global Prisma client to reuse across hot reloads */
+export const prisma = globalThis.prisma || new PrismaClient();
+if (process.env.NODE_ENV !== 'production') globalThis.prisma = prisma;

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,0 +1,23 @@
+import { Server } from 'socket.io';
+import type { NextApiResponseServerIO } from '../types';
+
+/** In-memory game state for demo purposes */
+const games: Record<string, any> = {};
+
+/** Initializes Socket.IO server */
+export function initSocket(res: NextApiResponseServerIO) {
+  if (!res.socket.server.io) {
+    const io = new Server(res.socket.server, { path: '/api/socket' });
+    res.socket.server.io = io;
+    io.on('connection', (socket) => {
+      socket.on('join', (gameId) => {
+        socket.join(gameId);
+        socket.emit('state', games[gameId] || {});
+      });
+      socket.on('update', ({ gameId, data }) => {
+        games[gameId] = data;
+        io.to(gameId).emit('state', data);
+      });
+    });
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-800;
+}

--- a/src/tests/basic.test.ts
+++ b/src/tests/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('demo test', () => {
+  it('adds numbers', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,7 @@
+import type { Server as HTTPServer } from 'http';
+import type { Socket } from 'net';
+import type { NextApiResponse } from 'next';
+
+export interface NextApiResponseServerIO extends NextApiResponse {
+  socket: Socket & { server: HTTPServer & { io: any } };
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "src/**/*.{ts,tsx}", "prisma/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js 14 + Tailwind scaffold
- configure NextAuth with credential and email providers
- set up Prisma models for game state
- implement socket.io server
- create basic pages for lobby, game and results
- add Docker Compose for Postgres and Next.js

## Testing
- `pnpm test` *(fails: vitest not found)*